### PR TITLE
Fix logic of when to skip a step

### DIFF
--- a/ptr.py
+++ b/ptr.py
@@ -418,15 +418,18 @@ async def _test_steps_runner(
     steps_ran = 0
     for a_step in steps:
         a_test_result = None
-        steps_ran += 1
         # Skip test if disabled & not asked for print coverage on analyze_coverage
-        if not a_step.run_condition and (
-            not print_cov and a_step.step_name is StepName.analyze_coverage
-        ):
-            LOG.info("Not running {} step".format(a_step.log_message))
-            continue
+        if not a_step.run_condition:
+            if (
+                a_step.step_name is not StepName.analyze_coverage
+                or not print_cov
+                and a_step.step_name is StepName.analyze_coverage
+            ):
+                LOG.info("Not running {} step".format(a_step.log_message))
+                continue
 
         LOG.info(a_step.log_message)
+        steps_ran += 1
         try:
             if a_step.cmds:
                 LOG.debug("CMD: {}".format(" ".join(a_step.cmds)))

--- a/ptr_tests.py
+++ b/ptr_tests.py
@@ -8,6 +8,7 @@
 import asyncio
 import unittest
 from collections import defaultdict
+from copy import deepcopy
 from pathlib import Path
 from platform import system
 from shutil import rmtree
@@ -314,8 +315,27 @@ class TestPtr(unittest.TestCase):
             fake_venv_path = td_path / "unittest_venv"
             fake_venv_lib_path = fake_venv_path / "lib"
             fake_venv_lib_path.mkdir(parents=True)
-            fake_tests_to_run = {fake_setup_py: ptr_tests_fixtures.EXPECTED_TEST_PARAMS}
 
+            # Run everything but black
+            etp = deepcopy(ptr_tests_fixtures.EXPECTED_TEST_PARAMS)
+            del (etp["run_black"])
+            fake_no_black_tests_to_run = {fake_setup_py: etp}
+            self.assertEqual(
+                self.loop.run_until_complete(
+                    ptr._test_steps_runner(
+                        69,
+                        fake_no_black_tests_to_run,
+                        fake_setup_py,
+                        fake_venv_path,
+                        {},
+                        True,
+                    )
+                ),
+                (None, 4),
+            )
+
+            # Run everything including black
+            fake_tests_to_run = {fake_setup_py: ptr_tests_fixtures.EXPECTED_TEST_PARAMS}
             self.assertEqual(
                 self.loop.run_until_complete(
                     ptr._test_steps_runner(


### PR DESCRIPTION
- Add a unit test for `_test_steps_runner` with no "run_black" key and ensure it does not run

Test via ptr:
```
-- Summary (total time 6s):

✅ PASS: 1
❌ FAIL: 0
⌛️ TIMEOUT: 0
💩 TOTAL: 1

-- 1 / 1 (100%) `setup.py`'s have `ptr` tests running
```

Issue: #11 
