### PR TITLE
Add support for [ptr] config in setup.cfg

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.5
+python_version = 3.6
 check_untyped_defs = True
 disallow_incomplete_defs = True
 disallow_untyped_decorators = True

--- a/ptr_tests.py
+++ b/ptr_tests.py
@@ -241,6 +241,18 @@ class TestPtr(unittest.TestCase):
         with self.assertRaises(SystemExit):
             ptr.main()
 
+    def test_parse_setup_cfg(self) -> None:
+        tmp_dir = Path(gettempdir())
+        setup_cfg = tmp_dir / "setup.cfg"
+        setup_py = tmp_dir / "setup.py"
+
+        with setup_cfg.open("w") as scp:
+            scp.write(ptr_tests_fixtures.SAMPLE_SETUP_CFG)
+
+        self.assertEqual(
+            ptr.parse_setup_cfg(setup_py), ptr_tests_fixtures.EXPECTED_TEST_PARAMS
+        )
+
     @patch("ptr.print")  # noqa
     def test_print_test_results(self, mock_print: Mock) -> None:
         stats = ptr.print_test_results(ptr_tests_fixtures.EXPECTED_COVERAGE_RESULTS)

--- a/ptr_tests_fixtures.py
+++ b/ptr_tests_fixtures.py
@@ -24,7 +24,7 @@ EXPECTED_TEST_PARAMS = {
     "entry_point_module": "ptr",
     "test_suite": "ptr_tests",
     "test_suite_timeout": 120,
-    "required_coverage": {"ptr.py": 84, "TOTAL": 90},
+    "required_coverage": {"ptr.py": 85, "TOTAL": 91},
     "run_black": True,
     "run_mypy": True,
 }
@@ -146,6 +146,17 @@ setup(
     install_requires=["click", "tabulate"],
     test_suite=ptr_params["test_suite"],
 )
+"""
+
+SAMPLE_SETUP_CFG = """\
+[ptr]
+entry_point_module = ptr
+test_suite = ptr_tests
+test_suite_timeout = 120
+required_coverage_ptr.py = 85
+required_coverage_TOTAL = 91
+run_black = true
+run_mypy = true
 """
 
 SAMPLE_SETUP_PY_PTR = {

--- a/setup.cfg.sample
+++ b/setup.cfg.sample
@@ -1,8 +1,9 @@
 [ptr]
 entry_point_module = ptr
 test_suite = ptr_tests
-test_suite_timeout = 300
-# TODO: Make this more ini like? - Big JSON will get U G L Y
-required_coverage = {"ptr.py": 84, "TOTAL": 90}
+test_suite_timeout = 120
+# `required_coverage_` will be stripped for use
+required_coverage_ptr.py = 84
+required_coverage_TOTAL = 90
 run_black = true
 run_mypy = true

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ ptr_params = {
     "test_suite": "ptr_tests",
     "test_suite_timeout": 120,
     # Relative path from setup.py to module (e.g. ptr == ptr.py)
-    "required_coverage": {"ptr.py": 84, "TOTAL": 90},
+    "required_coverage": {"ptr.py": 85, "TOTAL": 91},
     # Run black or not
     "run_black": True,
     # Run mypy or not


### PR DESCRIPTION
- Add parsing of a setup.cfg if it exists and has a ptr section
- Basically convert setup.cfg to same format as ptr_params dict
- Add test to show function works
- Increased unit test %
- Move mypy to allow for >= 3.6 features

Issue #1
