### PR TITLE
Add Mac OS X azure Pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,34 @@
+trigger:
+- master
+
+jobs:
+
+- job: 'Testing_ptr_Mac'
+  pool:
+    vmImage: 'macOS-10.13'
+  strategy:
+    matrix:
+      Python36:
+        python.version: '3.6'
+        ci.env: 'py36'
+      Python36Integration:
+        python.version: '3.6'
+        ci.env: 'PTR_INTEGRATION'
+      Python37:
+        python.version: '3.7'
+        ci.env: 'py37'
+      Python37Integration:
+        python.version: '3.7'
+        ci.env: 'PTR_INTEGRATION'
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+      architecture: 'x64'
+
+  - script: python -m pip install -r requirements.txt
+    displayName: 'Install ptr dependencies'
+
+  - script: export $(ci.env)=1 ; python ci.py
+    displayName: 'Running CI for $(ci.env)'


### PR DESCRIPTION
Summary:
- Add Mac OS X testing through azure

Test Plan:
- See CI pass

Issue: #3 
