### PR TITLE
Ignore dotted directories when running black

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ celerybeat-schedule
 .env
 
 # virtualenv
+.venv/
 venv/
 ENV/
 

--- a/ptr.py
+++ b/ptr.py
@@ -571,7 +571,7 @@ async def create_venv(
 
 
 def find_py_files(py_files: Set[str], base_dir: Path) -> None:
-    dirs = [d for d in base_dir.iterdir() if d.is_dir()]
+    dirs = [d for d in base_dir.iterdir() if d.is_dir() and not d.name.startswith(".")]
     py_files.update(
         {str(x) for x in base_dir.iterdir() if x.is_file() and x.suffix == ".py"}
     )


### PR DESCRIPTION
When developing `ptr` using a virtualenv inside the git repo (eg, `ptr/.venv/`), running `ptr` ends up also running **black** on the entire contents of the virtualenv.  This adds a simple filter to `find_py_files` to ignore directories with names that start with a dot.  Also adds `.venv` to `.gitignore` to facilitate this manner of development. 

Test Plan:
- `ptr` before and after