### PR TITLE
Fix #23: Support external module tests

### DIFF
--- a/ptr_tests_fixtures.py
+++ b/ptr_tests_fixtures.py
@@ -24,6 +24,7 @@ class FakeEventLoop:
 EXPECTED_TEST_PARAMS = {
     "entry_point_module": "ptr",
     "test_suite": "ptr_tests",
+    "test_suite_extras": ["ptr_tests_fixtures.py", "setup.py", "ptrconfig.sample"],
     "test_suite_timeout": 120,
     "required_coverage": {"ptr.py": 85, "TOTAL": 90},
     "run_black": True,
@@ -162,6 +163,7 @@ SAMPLE_SETUP_CFG = """\
 [ptr]
 entry_point_module = ptr
 test_suite = ptr_tests
+test_suite_extras = ptr_tests_fixtures.py setup.py ptrconfig.sample
 test_suite_timeout = 120
 required_coverage_ptr.py = 85
 required_coverage_TOTAL = 90

--- a/setup.cfg.sample
+++ b/setup.cfg.sample
@@ -1,6 +1,7 @@
 [ptr]
 entry_point_module = ptr
 test_suite = ptr_tests
+test_suite_extras = ptr_tests_fixtures.py setup.py ptrconfig.sample
 test_suite_timeout = 120
 # `required_coverage_` will be stripped for use
 required_coverage_ptr.py = 84

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ ptr_params = {
     "entry_point_module": "ptr",
     # Base Unittest File
     "test_suite": "ptr_tests",
+    "test_suite_extras": ["ptr_tests_fixtures.py", "setup.py", "ptrconfig.sample"],
     "test_suite_timeout": 120,
     # Relative path from setup.py to module (e.g. ptr == ptr.py)
     "required_coverage": {"ptr.py": 85, "TOTAL": 90},


### PR DESCRIPTION
Modifies ptr's handling of test suites to support test suites that
expect to be in the import path.  Looks for files or directories in the
module directory matching the `test_suite` config value, and also adds a
new config value `test_suite_extras` to list more files or directories
needed for tests. ptr will then copy all of these files and directories
into the root of the virtualenv, and then use the `-m` flag to coverage
to run the test suite. This works for ptr's single-file test suite
(with fixtures and config files listed as "extras") as well as for
package/module-based tests like those in aiosqlite.

Issue: #23
