### PR TITLE
Just disable Black on Windows 3.7 only + Enable CI

### DIFF
--- a/.pylint
+++ b/.pylint
@@ -516,7 +516,7 @@ valid-metaclass-classmethod-first-arg=mcs
 [DESIGN]
 
 # Maximum number of arguments for function / method
-max-args=10
+max-args=15
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=8

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,12 +36,10 @@ jobs:
       Python37:
         python.version: '3.7'
         ci.env: 'py37'
-# Renable when `black.exe` works with Python 3.7
-# https://github.com/ambv/black/issues/728
-#      Python37Integration:
-#        python.version: '3.7'
-#        ci.env: 'PTR_INTEGRATION'
-#        pythonioencoding: 'utf-8'
+      Python37Integration:
+        python.version: '3.7'
+        ci.env: 'PTR_INTEGRATION'
+        pythonioencoding: 'utf-8'
 
   steps:
   - task: UsePythonVersion@0

--- a/ptr.py
+++ b/ptr.py
@@ -400,9 +400,6 @@ def _run_black(config: Dict, force_black: bool = False) -> bool:
         )
         return False
 
-    if force_black:
-        return True
-
     return bool("run_black" in config and config["run_black"])
 
 

--- a/ptr.py
+++ b/ptr.py
@@ -389,6 +389,23 @@ async def _progress_reporter(
     LOG.debug("progress_reporter finished")
 
 
+# TODO: Remove when black works with Python 3.7 on Windows
+def _run_black(config: Dict, force_black: bool = False) -> bool:
+    """ Check if we're Windows and Python 3.7 or disabled via config
+       `black.exe` is broken with Python 3.7 - Issue Open:
+       https://github.com/ambv/black/issues/728 """
+    if not force_black and WINDOWS and sys.version_info >= (3, 7):
+        LOG.error(
+            "black is hard disabled due to not working with Python 3.7 on Windows"
+        )
+        return False
+
+    if force_black:
+        return True
+
+    return bool("run_black" in config and config["run_black"])
+
+
 def _set_build_env(build_base_path: Optional[Path]) -> Dict[str, str]:
     build_environ = environ.copy()
     if not build_base_path or not build_base_path.exists():
@@ -444,6 +461,7 @@ async def _test_steps_runner(
     env: Dict,
     stats: Dict[str, int],
     print_cov: bool = False,
+    force_black: bool = False,
 ) -> Tuple[Optional[test_result], int]:
     bin_dir = "Scripts" if WINDOWS else "bin"
     exe = ".exe" if WINDOWS else ""
@@ -490,7 +508,7 @@ async def _test_steps_runner(
         ),
         step(
             StepName.black_run,
-            bool("run_black" in config and config["run_black"]),
+            _run_black(config, force_black),
             _generate_black_cmd(setup_py_path.parent, black_exe),
             "Running black for {}".format(setup_py_path),
             config["test_suite_timeout"],
@@ -586,6 +604,7 @@ async def _test_runner(
     test_results: List[test_result],
     venv_path: Path,
     print_cov: bool,
+    force_black: bool,
     stats: Dict[str, int],
     idx: int,
 ) -> None:
@@ -618,6 +637,7 @@ async def _test_runner(
             env,
             stats,
             print_cov,
+            force_black,
         )
         total_success_runtime = int(time() - test_run_start_time)
         if test_fail_result:
@@ -805,6 +825,7 @@ async def run_tests(
     venv_path: Optional[Path],
     venv_keep: bool,
     print_cov: bool,
+    force_black: bool,
     stats: Dict[str, int],
     stats_file: str,
     venv_timeout: float,
@@ -833,7 +854,14 @@ async def run_tests(
     test_results = []  # type: List[test_result]
     consumers = [
         _test_runner(
-            queue, tests_to_run, test_results, venv_path, print_cov, stats, i + 1
+            queue,
+            tests_to_run,
+            test_results,
+            venv_path,
+            print_cov,
+            force_black,
+            stats,
+            i + 1,
         )
         for i in range(atonce)
     ]
@@ -869,6 +897,7 @@ async def async_main(
     venv: str,
     venv_keep: bool,
     print_cov: bool,
+    force_black: bool,
     stats_file: str,
     venv_timeout: float,
 ) -> int:
@@ -898,6 +927,7 @@ async def async_main(
         venv_path,
         venv_keep,
         print_cov,
+        force_black,
         stats,
         stats_file,
         venv_timeout,
@@ -924,6 +954,11 @@ def main() -> None:
     )
     parser.add_argument(
         "-d", "--debug", action="store_true", help="Verbose debug output"
+    )
+    parser.add_argument(
+        "--force-black",
+        action="store_true",
+        help="Ensure black runs if enabled in config",
     )
     parser.add_argument(
         "-k", "--keep-venv", action="store_true", help="Do not remove created venv"
@@ -974,6 +1009,7 @@ def main() -> None:
                     args.venv,
                     args.keep_venv,
                     args.print_cov,
+                    args.force_black,
                     args.stats_file,
                     args.venv_timeout,
                 )

--- a/ptr_tests.py
+++ b/ptr_tests.py
@@ -129,7 +129,7 @@ class TestPtr(unittest.TestCase):
     @patch("ptr.run_tests", async_none)
     @patch("ptr._get_test_modules")
     def test_async_main(self, mock_gtm: Mock) -> None:
-        args = [1, Path("/"), "mirror", 1, "venv", True, True, "stats", 30]
+        args = [1, Path("/"), "mirror", 1, "venv", True, True, False, "stats", 30]
         mock_gtm.return_value = False
         self.assertEqual(self.loop.run_until_complete(ptr.async_main(*args)), 1)
         mock_gtm.return_value = True
@@ -335,6 +335,13 @@ class TestPtr(unittest.TestCase):
         )
         self.assertEqual(mock_log.call_count, 2)
 
+    def test_run_black(self) -> None:
+        config = {}  # type: Dict[str, Any]
+        self.assertFalse(ptr._run_black(config, False))
+        self.assertTrue(ptr._run_black(config, True))
+        config["run_black"] = True
+        self.assertTrue(ptr._run_black(config, False))
+
     def test_set_build_env(self) -> None:
         local_build_path = Path(gettempdir())
         build_env = ptr._set_build_env(local_build_path)
@@ -371,7 +378,7 @@ class TestPtr(unittest.TestCase):
             stats = defaultdict(int)  # type: Dict[str, int]
             self.loop.run_until_complete(
                 ptr._test_runner(
-                    queue, tests_to_run, test_results, td_path, False, stats, 69
+                    queue, tests_to_run, test_results, td_path, False, False, stats, 69
                 )
             )
             self.assertEqual(len(test_results), 1)


### PR DESCRIPTION
Summary:
- Allow ptr integration run on Windows 3.7
- We will just not run black for now until black is fixed for Python 3.7 on Windows and released to PyPI


Test Plan:
- Test new function and docstring as to why it exists

Issue: #2 
