### PR TITLE
Add step_name to failure output

### DIFF
--- a/ptr.py
+++ b/ptr.py
@@ -780,7 +780,9 @@ def print_test_results(
                 stats["total.timeouts"] += 1
             else:
                 stats["total.fails"] += 1
-            fail_output += "{}:\n{}\n".format(result.setup_py_path, result.output)
+            fail_output += "{} (failed '{}' step):\n{}\n".format(
+                result.setup_py_path, StepName(result.returncode).name, result.output
+            )
         else:
             stats["total.passes"] += 1
 


### PR DESCRIPTION
- Allow developer to more easily know what underlying step failed

Test Plan:
Made a type error:
```
cooper-mbp:ptr cooper$ ~/venvs/pd/bin/python ptr.py --venv ~/venvs/pd/
[2019-03-28 16:15:43,281] INFO: Starting ptr.py (ptr.py:998)
[2019-03-28 16:15:43,370] INFO: Installing /Users/cooper/repos/ptr/setup.py + deps (ptr.py:542)
[2019-03-28 16:15:45,635] INFO: Running ptr_tests tests via coverage (ptr.py:542)
[2019-03-28 16:15:49,182] INFO: Analyzing coverage report for /Users/cooper/repos/ptr/setup.py (ptr.py:542)
[2019-03-28 16:15:49,454] INFO: Running mypy for /Users/cooper/repos/ptr/setup.py (ptr.py:542)
-- Summary (total time 7s):

✅ PASS: 0
❌ FAIL: 1
⌛️ TIMEOUT: 0
💩 TOTAL: 1

-- 1 / 1 (100%) `setup.py`'s have `ptr` tests running

-- Failure Output --

/Users/cooper/repos/ptr/setup.py (failed 'mypy_run' step):
ptr.py: note: In function "create_venv":
ptr.py:673: error: Argument 2 to "_set_pip_mirror" has incompatible type "int"; expected "str"
ptr.py: note: In function "run_tests":
ptr.py:836: error: Argument "mirror" to "create_venv" has incompatible type "str"; expected "int"

[2019-03-28 16:15:50,379] INFO: Not removing venv @ /Users/cooper/venvs/pd due to CLI arguments (ptr.py:886)
```

Fixes #31
