### PR TITLE
Add pyre type checking to ptr ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ UNKNOWN.egg-info/
 /.mypy_cache
 /.pytest_cache
 /docs/html
+
+# pyre checking
+.pyre/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
       env: PTR_INTEGRATION=1
     - python: 3.7
     - python: 3.7
+      env: PYRE_CHECK=1
+    - python: 3.7
       env: PTR_INTEGRATION=1
     - python: 3.8-dev
   allow_failures:

--- a/ci.py
+++ b/ci.py
@@ -75,15 +75,25 @@ def integration_test() -> int:
     return cp.returncode + check_ptr_stats_json(stats_file)
 
 
+def pyre_check() -> int:
+    print("Running `pyre` type checking", file=stderr)
+    pyre_cmd = ["pyre", "--source-directory", ".", "check"]
+    cp = run(pyre_cmd, check=True)
+    return cp.returncode
+
+
 def ci(show_env: bool = False) -> int:
     # Output exact python version
-    cp = run(("python", "-V"), stdout=PIPE, universal_newlines=True)
+    cp = run(("python3", "-V"), stdout=PIPE, universal_newlines=True)
     print("Using {}".format(cp.stdout), file=stderr)
 
     if show_env:
         print("- Environment:", file=stderr)
         for key in sorted(environ.keys()):
             print("{}: {}".format(key, environ[key]), file=stderr)
+
+    if "PYRE_CHECK" in environ:
+        return pyre_check()
 
     # Azure sets CI_ENV=PTR_INTEGRATION
     # Travis sets PTR_INTEGRATION=1

--- a/ci.py
+++ b/ci.py
@@ -84,7 +84,7 @@ def pyre_check() -> int:
 
 def ci(show_env: bool = False) -> int:
     # Output exact python version
-    cp = run(("python3", "-V"), stdout=PIPE, universal_newlines=True)
+    cp = run(("python", "-V"), stdout=PIPE, universal_newlines=True)
     print("Using {}".format(cp.stdout), file=stderr)
 
     if show_env:

--- a/ptr.py
+++ b/ptr.py
@@ -669,7 +669,7 @@ async def create_venv(
     else:
         pip_exe = venv_path / "bin" / "pip"
 
-    install_cmd = []
+    install_cmd: List[str] = []
     try:
         await _gen_check_output((py_exe, "-m", "venv", str(venv_path)), timeout=timeout)
         _set_pip_mirror(venv_path, mirror)

--- a/ptr.py
+++ b/ptr.py
@@ -375,7 +375,7 @@ async def _gen_check_output(
 
 
 async def _progress_reporter(
-    progress_interval: Union[float, int], queue: asyncio.Queue, total_tests: int
+    progress_interval: float, queue: asyncio.Queue, total_tests: int
 ) -> None:
     while queue.qsize() > 0:
         done_count = total_tests - queue.qsize()
@@ -540,6 +540,7 @@ async def _test_steps_runner(
                 continue
 
         LOG.info(a_step.log_message)
+        stdout = b""
         steps_ran += 1
         try:
             if a_step.cmds:
@@ -575,7 +576,7 @@ async def _test_steps_runner(
             )
 
         if a_step.step_name is StepName.analyze_coverage:
-            cov_report = stdout.decode("utf8")
+            cov_report = stdout.decode("utf8") if stdout else ""
             if print_cov:
                 print("{}:\n{}".format(setup_py_path, cov_report))
 
@@ -668,6 +669,7 @@ async def create_venv(
     else:
         pip_exe = venv_path / "bin" / "pip"
 
+    install_cmd = []
     try:
         await _gen_check_output((py_exe, "-m", "venv", str(venv_path)), timeout=timeout)
         _set_pip_mirror(venv_path, mirror)

--- a/ptr_tests.py
+++ b/ptr_tests.py
@@ -132,12 +132,18 @@ class TestPtr(unittest.TestCase):
     def test_async_main(self, mock_gtm: Mock) -> None:
         args = [1, Path("/"), "mirror", 1, "venv", True, True, False, "stats", 30]
         mock_gtm.return_value = False
-        self.assertEqual(self.loop.run_until_complete(ptr.async_main(*args)), 1)  # pyre-ignore
+        self.assertEqual(
+            self.loop.run_until_complete(ptr.async_main(*args)), 1  # pyre-ignore
+        )
         mock_gtm.return_value = True
-        self.assertEqual(self.loop.run_until_complete(ptr.async_main(*args)), 2)  # pyre-ignore
+        self.assertEqual(
+            self.loop.run_until_complete(ptr.async_main(*args)), 2  # pyre-ignore
+        )
         # Make Path() throw a TypeError on purpose
         args[4] = 0.69  # pyre-ignore
-        self.assertIsNone(self.loop.run_until_complete(ptr.async_main(*args)))  # pyre-ignore
+        self.assertIsNone(
+            self.loop.run_until_complete(ptr.async_main(*args))  # pyre-ignore
+        )
 
     def test_config(self) -> None:
         expected_pypi_url = "https://pypi.org/simple/"
@@ -147,7 +153,9 @@ class TestPtr(unittest.TestCase):
 
         td = Path(__file__).parent
         sc = ptr._config_read(str(td), "ptrconfig.sample")
-        self.assertEqual(sc["ptr"].get("pypi_url", ""), expected_pypi_url)  # pyre-ignore
+        self.assertEqual(
+            sc["ptr"].get("pypi_url", ""), expected_pypi_url  # pyre-ignore
+        )
         self.assertEqual(len(sc["ptr"].get("venv_pkgs", "").split()), 7)  # pyre-ignore
 
     @patch("ptr._gen_check_output", async_none)  # noqa

--- a/ptr_tests.py
+++ b/ptr_tests.py
@@ -132,12 +132,12 @@ class TestPtr(unittest.TestCase):
     def test_async_main(self, mock_gtm: Mock) -> None:
         args = [1, Path("/"), "mirror", 1, "venv", True, True, False, "stats", 30]
         mock_gtm.return_value = False
-        self.assertEqual(self.loop.run_until_complete(ptr.async_main(*args)), 1)
+        self.assertEqual(self.loop.run_until_complete(ptr.async_main(*args)), 1)  # pyre-ignore
         mock_gtm.return_value = True
-        self.assertEqual(self.loop.run_until_complete(ptr.async_main(*args)), 2)
-        # Make Path() throw a TypeError
-        args[4] = 0.69
-        self.assertIsNone(self.loop.run_until_complete(ptr.async_main(*args)))
+        self.assertEqual(self.loop.run_until_complete(ptr.async_main(*args)), 2)  # pyre-ignore
+        # Make Path() throw a TypeError on purpose
+        args[4] = 0.69  # pyre-ignore
+        self.assertIsNone(self.loop.run_until_complete(ptr.async_main(*args)))  # pyre-ignore
 
     def test_config(self) -> None:
         expected_pypi_url = "https://pypi.org/simple/"
@@ -147,8 +147,8 @@ class TestPtr(unittest.TestCase):
 
         td = Path(__file__).parent
         sc = ptr._config_read(str(td), "ptrconfig.sample")
-        self.assertEqual(sc["ptr"]["pypi_url"], expected_pypi_url)
-        self.assertEqual(len(sc["ptr"]["venv_pkgs"].split()), 7)
+        self.assertEqual(sc["ptr"].get("pypi_url", ""), expected_pypi_url)  # pyre-ignore
+        self.assertEqual(len(sc["ptr"].get("venv_pkgs", "").split()), 7)  # pyre-ignore
 
     @patch("ptr._gen_check_output", async_none)  # noqa
     @patch("ptr._set_pip_mirror")  # noqa
@@ -332,7 +332,7 @@ class TestPtr(unittest.TestCase):
         queue.qsize = qsize  # noqa
 
         self.loop.run_until_complete(
-            ptr._progress_reporter(0.1, queue, TOTAL_REPORTER_TESTS / 2)
+            ptr._progress_reporter(0.1, queue, int(TOTAL_REPORTER_TESTS / 2))
         )
         self.assertEqual(mock_log.call_count, 2)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ flake8
 mypy
 pip
 pylint
+pyre-check
 setuptools

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 # coding=utf8
+# pyre-ignore-all-errors
 
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
- Add into a venv and check + fix errors
```
python3 -m venv /tmp/pyre
/tmp/pyre/bin/pip install -r requirements.txt
/tmp/pyre/bin/pyre --source-directory . check
```
- Ignore `setup.py`
- Testing:
```
cooper-mbp1:ptr cooper$ /tmp/pyre/bin/python3 ci.py
Using Python 3.6.2+

Running `pyre` type checking
 ƛ Setting up a `.pyre_configuration` with `pyre init` may reduce overhead.
 ƛ No type errors found
```

Fixes #38
