### PR TITLE
Add disabled config option

### DIFF
--- a/ci.py
+++ b/ci.py
@@ -71,8 +71,8 @@ def integration_test() -> int:
         "python",
         "ptr.py",
         "-d",
-        "--force",
         "--print-cov",
+        "--run-disabled",
         "--stats-file",
         str(stats_file),
     ]

--- a/ci.py
+++ b/ci.py
@@ -67,7 +67,15 @@ def integration_test() -> int:
     print("Running `ptr` integration tests (aka run itself)", file=stderr)
 
     stats_file = Path(gettempdir()) / "ptr_ci_stats"
-    ci_cmd = ["python", "ptr.py", "-d", "--print-cov", "--stats-file", str(stats_file)]
+    ci_cmd = [
+        "python",
+        "ptr.py",
+        "-d",
+        "--force",
+        "--print-cov",
+        "--stats-file",
+        str(stats_file),
+    ]
     if "VIRTUAL_ENV" in environ:
         ci_cmd.extend(["--venv", environ["VIRTUAL_ENV"]])
 

--- a/ptr_tests.py
+++ b/ptr_tests.py
@@ -130,7 +130,7 @@ class TestPtr(unittest.TestCase):
     @patch("ptr.run_tests", async_none)
     @patch("ptr._get_test_modules")
     def test_async_main(self, mock_gtm: Mock) -> None:
-        args = [1, Path("/"), "mirror", 1, "venv", True, True, False, "stats", 30]
+        args = [1, Path("/"), "mirror", 1, "venv", True, True, True, False, "stats", 30]
         mock_gtm.return_value = False
         self.assertEqual(
             self.loop.run_until_complete(ptr.async_main(*args)), 1  # pyre-ignore
@@ -283,7 +283,7 @@ class TestPtr(unittest.TestCase):
     def test_get_test_modules(self) -> None:
         base_path = Path(__file__).parent
         stats = defaultdict(int)  # type: Dict[str, int]
-        test_modules = ptr._get_test_modules(base_path, stats)
+        test_modules = ptr._get_test_modules(base_path, stats, True)
         self.assertEqual(
             test_modules[base_path / "setup.py"],
             ptr_tests_fixtures.EXPECTED_TEST_PARAMS,

--- a/ptr_tests_fixtures.py
+++ b/ptr_tests_fixtures.py
@@ -23,7 +23,7 @@ class FakeEventLoop:
         return 0
 
 
-# Disabled is set as we --force the run in CI
+# Disabled is set as we --run-disabled the run in CI
 EXPECTED_TEST_PARAMS = {
     "disabled": True,
     "entry_point_module": "ptr",
@@ -189,7 +189,7 @@ setup(
 )
 """
 
-# Disabled is set as we --force the run in CI
+# Disabled is set as we --run-disabled the run in CI
 SAMPLE_SETUP_CFG = """\
 [ptr]
 disabled = true

--- a/ptr_tests_fixtures.py
+++ b/ptr_tests_fixtures.py
@@ -23,7 +23,9 @@ class FakeEventLoop:
         return 0
 
 
+# Disabled is set as we --force the run in CI
 EXPECTED_TEST_PARAMS = {
+    "disabled": True,
     "entry_point_module": "ptr",
     "test_suite": "ptr_tests",
     "test_suite_timeout": 120,
@@ -187,8 +189,10 @@ setup(
 )
 """
 
+# Disabled is set as we --force the run in CI
 SAMPLE_SETUP_CFG = """\
 [ptr]
+disabled = true
 entry_point_module = ptr
 test_suite = ptr_tests
 test_suite_timeout = 120

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools import setup
 
 # Specific Python Test Runner (ptr) params for Unit Testing Enforcement
 ptr_params = {
-    # Disable auto running if found - Requires --force to run
+    # Disable auto running if found - Requires --run-disabled to run
     "disabled": True,
     # Where mypy will run to type check your program
     "entry_point_module": "ptr",

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ from setuptools import setup
 
 # Specific Python Test Runner (ptr) params for Unit Testing Enforcement
 ptr_params = {
+    # Disable auto running if found - Requires --force to run
+    "disabled": True,
     # Where mypy will run to type check your program
     "entry_point_module": "ptr",
     # Base Unittest File


### PR DESCRIPTION
- Allow a test to be disabled so automatic discovery will ignore
- Add `--force` option to overrule the ignoring of disabled test suites
- Make tests suite disabled but use --force in CI to have them run

Fixes #46