### PR TITLE
Add `--print-non-configured` to print Non ptr enabled Python Projects

### DIFF
--- a/ptr.py
+++ b/ptr.py
@@ -998,7 +998,7 @@ async def async_main(
     )
 
 
-def main() -> int:
+def main() -> None:
     default_stats_file = Path(gettempdir()) / "ptr_stats_{}".format(getpid())
     parser = argparse.ArgumentParser()
     parser.add_argument(

--- a/ptr.py
+++ b/ptr.py
@@ -296,7 +296,10 @@ def _generate_pyre_cmd(
 
 
 def _get_test_modules(
-    base_path: Path, stats: Dict[str, int], run_disabled: bool
+    base_path: Path,
+    stats: Dict[str, int],
+    run_disabled: bool,
+    print_non_configured: bool,
 ) -> Dict[Path, Dict]:
     get_tests_start_time = time()
     all_setup_pys = find_setup_pys(
@@ -307,6 +310,7 @@ def _get_test_modules(
     )
     stats["total.setup_pys"] = len(all_setup_pys)
 
+    non_configured_modules = []  # type: List[Path]
     test_modules = {}  # type: Dict[Path, Dict]
     for setup_py in all_setup_pys:  # pylint: disable=R1702
         disabled_err_msg = "Not running {} as ptr is disabled via config".format(
@@ -345,7 +349,13 @@ def _get_test_modules(
                                     setup_py
                                 )
                             )
+        if setup_py not in test_modules:
+            non_configured_modules.append(setup_py)
 
+    if print_non_configured and non_configured_modules:
+        print_non_configured_modules(non_configured_modules)
+
+    stats["total.non_ptr_setup_pys"] = len(non_configured_modules)
     stats["total.ptr_setup_pys"] = len(test_modules)
     stats["runtime.parse_setup_pys"] = int(time() - get_tests_start_time)
     return test_modules
@@ -743,32 +753,35 @@ def find_py_files(py_files: Set[str], base_dir: Path) -> None:
         find_py_files(py_files, directory)
 
 
+def _recursive_find_files(
+    files: Set[Path], base_dir: Path, exclude_patterns: Set[str], follow_symlinks: bool
+) -> None:
+    dirs = [d for d in base_dir.iterdir() if d.is_dir()]
+    files.update(
+        {x for x in base_dir.iterdir() if x.is_file() and x.name == "setup.py"}
+    )
+    for directory in dirs:
+        if not follow_symlinks and directory.is_symlink():
+            continue
+
+        skip_dir = False
+        for exclude_pattern in exclude_patterns:
+            if directory.match(exclude_pattern):
+                skip_dir = True
+                LOG.debug(
+                    "Skipping {} due to exclude pattern {}".format(
+                        directory, exclude_pattern
+                    )
+                )
+        if not skip_dir:
+            _recursive_find_files(files, directory, exclude_patterns, follow_symlinks)
+
+
 def find_setup_pys(
     base_path: Path, exclude_patterns: Set[str], follow_symlinks: bool = False
 ) -> Set[Path]:
-    def _recursive_find_files(files: Set[Path], base_dir: Path) -> None:
-        dirs = [d for d in base_dir.iterdir() if d.is_dir()]
-        files.update(
-            {x for x in base_dir.iterdir() if x.is_file() and x.name == "setup.py"}
-        )
-        for directory in dirs:
-            if not follow_symlinks and directory.is_symlink():
-                continue
-
-            skip_dir = False
-            for exclude_pattern in exclude_patterns:
-                if directory.match(exclude_pattern):
-                    skip_dir = True
-                    LOG.debug(
-                        "Skipping {} due to exclude pattern {}".format(
-                            directory, exclude_pattern
-                        )
-                    )
-            if not skip_dir:
-                _recursive_find_files(files, directory)
-
     setup_pys = set()  # type: Set[Path]
-    _recursive_find_files(setup_pys, base_path)
+    _recursive_find_files(setup_pys, base_path, exclude_patterns, follow_symlinks)
     return setup_pys
 
 
@@ -801,6 +814,12 @@ def parse_setup_cfg(setup_py: Path) -> Dict[str, Any]:
             ptr_params[key] = value
 
     return ptr_params
+
+
+def print_non_configured_modules(modules: List[Path]) -> None:
+    print("== {} non ptr configured modules ==".format(len(modules)))
+    for module in sorted(modules):
+        print(" - {}".format(str(module)))
 
 
 def print_test_results(
@@ -935,13 +954,16 @@ async def async_main(
     venv: str,
     venv_keep: bool,
     print_cov: bool,
+    print_non_configured: bool,
     run_disabled: bool,
     force_black: bool,
     stats_file: str,
     venv_timeout: float,
 ) -> int:
     stats = defaultdict(int)  # type: Dict[str, int]
-    tests_to_run = _get_test_modules(base_path, stats, run_disabled)
+    tests_to_run = _get_test_modules(
+        base_path, stats, run_disabled, print_non_configured
+    )
     if not tests_to_run:
         LOG.error(
             "{} has no setup.py files with unit tests defined. Exiting".format(
@@ -949,6 +971,9 @@ async def async_main(
             )
         )
         return 1
+
+    if print_non_configured:
+        return 0
 
     try:
         venv_path = Path(venv)  # type: Optional[Path]
@@ -973,7 +998,7 @@ async def async_main(
     )
 
 
-def main() -> None:
+def main() -> int:
     default_stats_file = Path(gettempdir()) / "ptr_stats_{}".format(getpid())
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -1012,6 +1037,11 @@ def main() -> None:
     )
     parser.add_argument(
         "--print-cov", action="store_true", help="Print modules coverage report"
+    )
+    parser.add_argument(
+        "--print-non-configured",
+        action="store_true",
+        help="Print modules not configured to run ptr",
     )
     parser.add_argument(
         "--progress-interval",
@@ -1053,6 +1083,7 @@ def main() -> None:
                     args.venv,
                     args.keep_venv,
                     args.print_cov,
+                    args.print_non_configured,
                     args.run_disabled,
                     args.force_black,
                     args.stats_file,

--- a/ptr_tests_fixtures.py
+++ b/ptr_tests_fixtures.py
@@ -29,7 +29,7 @@ EXPECTED_TEST_PARAMS = {
     "entry_point_module": "ptr",
     "test_suite": "ptr_tests",
     "test_suite_timeout": 120,
-    "required_coverage": {"ptr.py": 84, "TOTAL": 89},
+    "required_coverage": {"ptr.py": 83, "TOTAL": 89},
     "run_black": True,
     "run_mypy": True,
     "run_flake8": True,
@@ -196,7 +196,7 @@ disabled = true
 entry_point_module = ptr
 test_suite = ptr_tests
 test_suite_timeout = 120
-required_coverage_ptr.py = 84
+required_coverage_ptr.py = 83
 required_coverage_TOTAL = 89
 run_black = true
 run_mypy = true

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ ptr_params = {
     "test_suite": "ptr_tests",
     "test_suite_timeout": 120,
     # Relative path from setup.py to module (e.g. ptr == ptr.py)
-    "required_coverage": {"ptr.py": 84, "TOTAL": 89},
+    "required_coverage": {"ptr.py": 83, "TOTAL": 89},
     # Run black or not
     "run_black": True,
     # Run mypy or not
@@ -47,7 +47,7 @@ def get_long_desc() -> str:
 
 setup(
     name=ptr_params["entry_point_module"],
-    version="19.6.15",
+    version="19.7.16",
     description="Parallel asyncio Python setup.(cfg|py) Test Runner",
     long_description=get_long_desc(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
- Make it easier to find missed `setup.(cfg|py)`
- Add unit tests

Sample Output from tests:
```
cooper-mbp1:terragraph-ansible cooper$ time /tmp/test_non_ptr_mods/bin/ptr --print-non-configured
[2019-07-16 09:08:43,483] INFO: Starting /tmp/test_non_ptr_mods/bin/ptr (ptr.py:1070)
== 8 non ptr configured modules ==
 - /Users/cooper/repos/terragraph-ansible/dns_ldap_checker/setup.py
 - /Users/cooper/repos/terragraph-ansible/docker_proxy/setup.py
 - /Users/cooper/repos/terragraph-ansible/docker_v6up/setup.py
 - /Users/cooper/repos/terragraph-ansible/esxi_ssh_monitor/setup.py
 - /Users/cooper/repos/terragraph-ansible/iperfc/setup.py
 - /Users/cooper/repos/terragraph-ansible/jenkins/NMS_push_e2e_controller/setup.py
 - /Users/cooper/repos/terragraph-ansible/nms_ip_getter/setup.py
 - /Users/cooper/repos/terragraph-ansible/nms_stack/setup.py

real	0m0.432s
user	0m0.225s
sys	0m0.204s
```

Fixes #50 
