### PR TITLE
Refactor _get_test_modules function to remove lint error.

### DIFF
--- a/ptr.py
+++ b/ptr.py
@@ -306,7 +306,7 @@ def _parse_setup_params(setup_py: Path) -> Dict[str, Any]:
                 # mypy error: "expr" has no attribute "id"
                 if target.id == "ptr_params":  # type: ignore
                     LOG.debug("Found ptr_params in {}".format(setup_py))
-                    ptr_params = ast.literal_eval(node.value)
+                    ptr_params = dict(ast.literal_eval(node.value))
                     if "test_suite" in ptr_params:
                         return ptr_params
                     LOG.info(


### PR DESCRIPTION
Summary:
- Move the parsing of the setup.py file out of `_get_test_modules` to clean up the function and remove the lint warning.

Test Plan:
- Ran `ptr_tests.py` and ensured nothing broke. 
- Ran `pylint` on `ptr.py` and verified the error was gone.

Issue: #48 
