### PR TITLE
Fix AST pasing of setup.py to handle `targets` with no id attribute

### DIFF
--- a/ptr.py
+++ b/ptr.py
@@ -303,8 +303,11 @@ def _parse_setup_params(setup_py: Path) -> Dict[str, Any]:
     for node in ast.walk(setup_tree):
         if isinstance(node, ast.Assign):
             for target in node.targets:
-                # mypy error: "expr" has no attribute "id"
-                if target.id == "ptr_params":  # type: ignore
+                target_id = getattr(target, "id", None)
+                if not target_id:
+                    continue
+
+                if target_id == "ptr_params":
                     LOG.debug("Found ptr_params in {}".format(setup_py))
                     ptr_params = dict(ast.literal_eval(node.value))
                     if "test_suite" in ptr_params:

--- a/ptr_tests_fixtures.py
+++ b/ptr_tests_fixtures.py
@@ -29,7 +29,7 @@ EXPECTED_TEST_PARAMS = {
     "entry_point_module": "ptr",
     "test_suite": "ptr_tests",
     "test_suite_timeout": 120,
-    "required_coverage": {"ptr.py": 83, "TOTAL": 89},
+    "required_coverage": {"ptr.py": 84, "TOTAL": 89},
     "run_black": True,
     "run_mypy": True,
     "run_flake8": True,
@@ -196,7 +196,7 @@ disabled = true
 entry_point_module = ptr
 test_suite = ptr_tests
 test_suite_timeout = 120
-required_coverage_ptr.py = 83
+required_coverage_ptr.py = 84
 required_coverage_TOTAL = 89
 run_black = true
 run_mypy = true

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ ptr_params = {
     "test_suite": "ptr_tests",
     "test_suite_timeout": 120,
     # Relative path from setup.py to module (e.g. ptr == ptr.py)
-    "required_coverage": {"ptr.py": 83, "TOTAL": 89},
+    "required_coverage": {"ptr.py": 84, "TOTAL": 89},
     # Run black or not
     "run_black": True,
     # Run mypy or not
@@ -47,7 +47,7 @@ def get_long_desc() -> str:
 
 setup(
     name=ptr_params["entry_point_module"],
-    version="19.7.16",
+    version="19.8.7",
     description="Parallel asyncio Python setup.(cfg|py) Test Runner",
     long_description=get_long_desc(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
- Not all AST `targets` has an id
- Use `getattr` to get id if it exists otherwise set the variable to None and skip

Fixes #54
