### PR TITLE
Add CLI option to enable erroring on all warnings

### DIFF
--- a/.pylint
+++ b/.pylint
@@ -140,7 +140,8 @@ disable=print-statement,
         logging-format-interpolation,
         no-self-use,
         ungrouped-imports,
-        fixme
+        fixme,
+        too-many-function-args
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/ci.py
+++ b/ci.py
@@ -73,6 +73,7 @@ def integration_test() -> int:
         "-d",
         "--print-cov",
         "--run-disabled",
+        "--error-on-warnings",
         "--stats-file",
         str(stats_file),
     ]

--- a/ptr_tests.py
+++ b/ptr_tests.py
@@ -129,7 +129,20 @@ class TestPtr(unittest.TestCase):
     @patch("ptr.run_tests", async_none)
     @patch("ptr._get_test_modules")
     def test_async_main(self, mock_gtm: Mock) -> None:
-        args = [1, Path("/"), "mirror", 1, "venv", True, True, False, True, "stats", 30]
+        args = [
+            1,
+            Path("/"),
+            "mirror",
+            1,
+            "venv",
+            True,
+            True,
+            False,
+            True,
+            "stats",
+            30,
+            True,
+        ]
         mock_gtm.return_value = False
         self.assertEqual(
             self.loop.run_until_complete(ptr.async_main(*args)), 1  # pyre-ignore
@@ -404,7 +417,7 @@ class TestPtr(unittest.TestCase):
             stats = defaultdict(int)  # type: Dict[str, int]
             self.loop.run_until_complete(
                 ptr._test_runner(
-                    queue, tests_to_run, test_results, td_path, False, stats, 69
+                    queue, tests_to_run, test_results, td_path, False, stats, True, 69
                 )
             )
             self.assertEqual(len(test_results), 1)
@@ -433,6 +446,7 @@ class TestPtr(unittest.TestCase):
                         fake_venv_path,
                         {},
                         True,
+                        True,
                     )
                 ),
                 # Windows will not run pyre
@@ -456,6 +470,7 @@ class TestPtr(unittest.TestCase):
                         fake_venv_path,
                         {},
                         {},
+                        True,
                         True,
                     )
                 ),

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ def get_long_desc() -> str:
 
 setup(
     name=ptr_params["entry_point_module"],
-    version="19.8.7",
+    version="19.9.10",
     description="Parallel asyncio Python setup.(cfg|py) Test Runner",
     long_description=get_long_desc(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
- -e + --error-on-warnings added to raise ANY/ALL warning from warnings module
- Help people to find deprecations etc. when upgrading python
- Add to ci run to ensure we don't have any warnings

Summary:
- Please give us some dot points on why you made this PR

Test Plan:
- How did you ensure this did not break anything and does what you want?

Issue: #
