### PR TITLE
Add better handling for file not exists while in REQ_COV

### DIFF
--- a/ptr.py
+++ b/ptr.py
@@ -192,8 +192,19 @@ def _analyze_coverage(
 
     failed_output = "The following files did not meet coverage requirements:\n"
     failed_coverage = False
+
     for afile, cov_req in required_cov.items():
-        if coverage_lines[afile].cover < cov_req:
+        try:
+            cover = coverage_lines[afile].cover
+        except KeyError as ke:
+            LOG.error(
+                "{} has not reported any coverage. \\"
+                "Does the file exist? Does it get ran during tests? ({})".format(
+                    afile, str(ke)
+                )
+            )
+            return None
+        if cover < cov_req:
             failed_coverage = True
             failed_output += "  {}: {} < {} - Missing: {}\n".format(
                 afile,

--- a/ptr_tests.py
+++ b/ptr_tests.py
@@ -77,8 +77,9 @@ class TestPtr(unittest.TestCase):
             ptr._analyze_coverage(fake_path, fake_path, {}, "Fake Cov Report", {})
         )
 
+    @patch("ptr.LOG.error")
     @patch("ptr.getpid", return_specific_pid)
-    def test_analyze_coverage(self) -> None:
+    def test_analyze_coverage(self, mock_log: Mock) -> None:
         fake_setup_py = Path("unittest/setup.py")
         if "VIRTUAL_ENV" in environ:
             fake_venv_path = Path(environ["VIRTUAL_ENV"])
@@ -121,7 +122,12 @@ class TestPtr(unittest.TestCase):
             ),
             ptr_tests_fixtures.EXPECTED_PTR_COVERAGE_FAIL_RESULT,
         )
-
+        self.assertIsNone(
+            ptr._analyze_coverage(
+                fake_venv_path, fake_setup_py, {"fake_file.py": 48}, cov_report, {}
+            )
+        )
+        self.assertTrue(mock_log.called)
         # Dont delete the VIRTUAL_ENV carrying the test if we didn't make it
         if "VIRTUAL_ENV" not in environ:
             rmtree(fake_venv_path)


### PR DESCRIPTION
Summary:
- Add `KeyError` exception when a file is in required coverage while it doesn't exist.

Test Plan:
- Add a unit test for this specific case.

Issue: #51 
