### PR TITLE
[ptr] Move CI to 3.8 offical + nightly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ UNKNOWN.egg-info/
 
 # pyre checking
 .pyre/
+
+# vscode
+.vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,12 @@ matrix:
     - python: 3.7
     - python: 3.7
       env: PTR_INTEGRATION=1
-    - python: 3.8-dev
+    - python: 3.8
+    - python: 3.8
+      env: PTR_INTEGRATION=1
+    - python: nightly
   allow_failures:
-    - python: 3.8-dev
+    - python: nightly
 
 script:
     - python ci.py

--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ All done! 💥 💔 💥
 
 ### pyre
 
+- `pyre` is not currently supported on 3.8. libCST requires [3.8 Support](https://github.com/Instagram/LibCST/issues/122)
+
 ```
 cooper-mbp1:ptr cooper$ /tmp/tp/bin/ptr --venv /var/folders/tc/hbwxh76j1hn6gqjd2n2sjn4j9k1glp/T/ptr_venv_49117
 [2019-05-03 14:51:43,623] INFO: Starting /tmp/tp/bin/ptr (ptr.py:1023)

--- a/ptr_tests.py
+++ b/ptr_tests.py
@@ -476,11 +476,11 @@ class TestPtr(unittest.TestCase):
                         True,
                     )
                 ),
-                # Windows will not run pyre
-                (None, 6) if ptr.WINDOWS else (None, 7),
+                # Windows + Python 3.8 will not run pyre
+                (None, 6) if ptr.WINDOWS or ptr.GREATER_THAN_37 else (None, 7),
             )
 
-            if ptr.WINDOWS:
+            if ptr.WINDOWS or ptr.GREATER_THAN_37:
                 # No pyre
                 expected = (None, 7)
             else:

--- a/ptr_tests.py
+++ b/ptr_tests.py
@@ -34,7 +34,7 @@ TOTAL_REPORTER_TESTS = 4
 
 
 async def async_none(*args: Any, **kwargs: Any) -> None:
-    return
+    return None
 
 
 def fake_get_event_loop(*args: Any, **kwargs: Any) -> ptr_tests_fixtures.FakeEventLoop:

--- a/ptr_tests.py
+++ b/ptr_tests.py
@@ -305,13 +305,10 @@ class TestPtr(unittest.TestCase):
             pyre_exe = Path("pyre")
 
             conf = {"run_pyre": True}
-            if ptr.WINDOWS:
-                self.assertEqual(ptr._generate_pyre_cmd(td_path, pyre_exe, conf), ())
-            else:
-                self.assertEqual(
-                    ptr._generate_pyre_cmd(td_path, pyre_exe, conf),
-                    (str(pyre_exe), "--source-directory", str(td_path), "check"),
-                )
+            expected = (str(pyre_exe), "--source-directory", str(td_path), "check")
+            if ptr.WINDOWS or ptr.GREATER_THAN_37:
+                expected = ()
+            self.assertEqual(ptr._generate_pyre_cmd(td_path, pyre_exe, conf), expected)
 
     def test_get_site_packages_path_error(self) -> None:
         with TemporaryDirectory() as td:


### PR DESCRIPTION
Summary:
- Add a Integration run to 3.8 as we now want to support it officially
- Block on 3.8 fails
- Add a nightly so we can squash issues sooner

Test Plan:
- This is the diff to run test on my Python versions

Issue: N/A
