### PR TITLE
Add github action/workflow

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,15 +1,22 @@
 name: pythontestrunner
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+  pull_request:
 
 jobs:
   build:
-    name: Building ptr on python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    name: Building ptr for python ${{ matrix.python-version }} on ${{matrix.os}}
+    runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 4
       matrix:
         python-version: [3.6, 3.7]
+        os: [macOS-latest, ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,0 +1,30 @@
+name: pythontestrunner
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Building ptr on python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.6, 3.7]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: ptr-ci
+      run: |
+        python ci.py 
+    - name: ptr-ci-integration
+      env: 
+       PTR_INTEGRATION: 1
+      run: |
+        python ci.py 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 [![Build Status](https://travis-ci.com/facebookincubator/ptr.svg?token=mNAyoiwbJFtpeEWXdo5z&branch=master)](https://travis-ci.com/facebookincubator/ptr)
+![](https://github.com/facebookincubator/ptr/.github/workflows/pythonpackage.yml/badge.svg)
 
 Python Test Runner (ptr) was born to run tests in an opinionated way, within arbitrary code repositories.
 `ptr` supports many Python projects with unit tests defined in their `setup.(cfg|py)` files per repository.


### PR DESCRIPTION
Summary:
- Added github workflow for push and PR
- Removed azure-pipeline because the issue mentioned in #61 
- The only bummer here is that 3.8 isn't supported yet (wip [issue](https://github.com/actions/setup-python/issues/30)
  
Test Plan:
We might leave both Travis and Github action for a while maybe until the official release of GitHub Actions.
Issue: #61 
