### PR TITLE
Bug fix in atonce config param

### DIFF
--- a/ptr.py
+++ b/ptr.py
@@ -45,7 +45,7 @@ def _config_default() -> ConfigParser:
     LOG.info("Using default config settings")
     cp = ConfigParser()
     cp["ptr"] = {}
-    cp["ptr"]["atonce"] = str(int((cpu_count() or 20) / 2))
+    cp["ptr"]["atonce"] = str(int((cpu_count() or 20) / 2) or 1)
     cp["ptr"]["exclude_patterns"] = "build* yocto"
     cp["ptr"]["pypi_url"] = "https://pypi.org/simple/"
     cp["ptr"]["venv_pkgs"] = venv_pkgs


### PR DESCRIPTION
Summary:
- If `os.cpu_count()` is 1, `int` casting floors the atonce config param to 0. 

Test Plan:
- Ran on my lab VM. Ran ptr on default_routes service. 

