### PR TITLE
Run ptr even when test_suite is not provided

### DIFF
--- a/ptr.py
+++ b/ptr.py
@@ -286,7 +286,7 @@ def _generate_install_cmd(
     return tuple(cmds)
 
 
-def _generate_test_suite_cmd(coverage_exe, config: Dict) -> Tuple[str, ...]:
+def _generate_test_suite_cmd(coverage_exe: Path, config: Dict) -> Iterable:
     return (
         (str(coverage_exe), "run", "-m", config["test_suite"])
         if config.get("test_suite", False)

--- a/ptr.py
+++ b/ptr.py
@@ -286,7 +286,7 @@ def _generate_install_cmd(
     return tuple(cmds)
 
 
-def _generate_test_suite_cmd(coverage_exe: Path, config: Dict) -> Iterable:
+def _generate_test_suite_cmd(coverage_exe: Path, config: Dict) -> Tuple[str, ...]:
     return (
         (str(coverage_exe), "run", "-m", config["test_suite"])
         if config.get("test_suite", False)

--- a/ptr.py
+++ b/ptr.py
@@ -287,11 +287,10 @@ def _generate_install_cmd(
 
 
 def _generate_test_suite_cmd(coverage_exe: Path, config: Dict) -> Tuple[str, ...]:
-    return (
-        (str(coverage_exe), "run", "-m", config["test_suite"])
-        if config.get("test_suite", False)
-        else ()
-    )
+    if config.get("test_suite", False):
+        return (str(coverage_exe), "run", "-m", config["test_suite"])
+    else:
+        return ()
 
 
 def _generate_mypy_cmd(

--- a/ptr.py
+++ b/ptr.py
@@ -16,7 +16,7 @@ from enum import Enum
 from json import dump
 from os import chdir, cpu_count, environ, getcwd, getpid
 from os.path import sep
-from pathlib import Path, PosixPath
+from pathlib import Path
 from platform import system
 from shutil import rmtree
 from subprocess import CalledProcessError
@@ -286,7 +286,7 @@ def _generate_install_cmd(
     return tuple(cmds)
 
 
-def _generate_test_suite_cmd(coverage_exe: PosixPath, config: Dict) -> Tuple[str, ...]:
+def _generate_test_suite_cmd(coverage_exe, config: Dict) -> Tuple[str, ...]:
     return (
         (str(coverage_exe), "run", "-m", config["test_suite"])
         if config.get("test_suite", False)
@@ -620,15 +620,10 @@ async def _test_steps_runner(  # pylint: disable=R0914
     steps_ran = 0
     for a_step in steps:
         a_test_result = None
-        # Skip test if disabled & not asked for print coverage on analyze_coverage
+        # Skip test if disabled
         if not a_step.run_condition:
-            if (
-                a_step.step_name is not StepName.analyze_coverage
-                or not print_cov
-                and a_step.step_name is StepName.analyze_coverage
-            ):
-                LOG.info("Not running {} step".format(a_step.log_message))
-                continue
+            LOG.info("Not running {} step".format(a_step.log_message))
+            continue
 
         LOG.info(a_step.log_message)
         stdout = b""
@@ -688,7 +683,6 @@ async def _test_steps_runner(  # pylint: disable=R0914
                     stats,
                     test_run_start_time,
                 )
-
         # If we've had a failure return
         if a_test_result:
             return a_test_result, steps_ran

--- a/ptr.py
+++ b/ptr.py
@@ -289,8 +289,7 @@ def _generate_install_cmd(
 def _generate_test_suite_cmd(coverage_exe: Path, config: Dict) -> Tuple[str, ...]:
     if config.get("test_suite", False):
         return (str(coverage_exe), "run", "-m", config["test_suite"])
-    else:
-        return ()
+    return ()
 
 
 def _generate_mypy_cmd(

--- a/ptr_tests.py
+++ b/ptr_tests.py
@@ -262,7 +262,7 @@ class TestPtr(unittest.TestCase):
 
     def test_generate_test_suite_cmd(self) -> None:
         coverage_exe = Path("/bin/coverage")
-        with TemporaryDirectory() as td:
+        with TemporaryDirectory():
             config = {"test_suite": "dummy_test.base"}
             self.assertEqual(
                 ptr._generate_test_suite_cmd(coverage_exe, config),

--- a/ptr_tests.py
+++ b/ptr_tests.py
@@ -561,7 +561,7 @@ class TestPtr(unittest.TestCase):
                     )
                 ),
                 # Windows + Python 3.8 will not run pyre
-                (None, 6) if ptr.WINDOWS or ptr.GREATER_THAN_37 else (None, 7),
+                (None, 5) if ptr.WINDOWS or ptr.GREATER_THAN_37 else (None, 6),
             )
 
             # Ensure we've "printed coverage"

--- a/ptr_tests.py
+++ b/ptr_tests.py
@@ -557,7 +557,7 @@ class TestPtr(unittest.TestCase):
                         {},
                         {},
                         True,
-                        True
+                        True,
                     )
                 ),
                 # Windows + Python 3.8 will not run pyre

--- a/ptr_tests.py
+++ b/ptr_tests.py
@@ -260,6 +260,18 @@ class TestPtr(unittest.TestCase):
             (python_exe, "-v", "install", module_dir, "peerme"),
         )
 
+    def test_generate_test_suite_cmd(self) -> None:
+        coverage_exe = Path("/bin/coverage")
+        with TemporaryDirectory() as td:
+            config = {"test_suite": "dummy_test.base"}
+            self.assertEqual(
+                ptr._generate_test_suite_cmd(coverage_exe, config),
+                (str(coverage_exe), "run", "-m", config["test_suite"]),
+            )
+
+            config = {}
+            self.assertEqual(ptr._generate_test_suite_cmd(coverage_exe, config), ())
+
     def test_generate_mypy_cmd(self) -> None:
         with TemporaryDirectory() as td:
             td_path = Path(td)
@@ -512,6 +524,46 @@ class TestPtr(unittest.TestCase):
                 ),
                 expected,
             )
+
+            # Run everything but test_suite without print-cov
+            etp = deepcopy(ptr_tests_fixtures.EXPECTED_TEST_PARAMS)
+            del etp["test_suite"]
+            del etp["required_coverage"]
+            fake_no_black_tests_to_run = {fake_setup_py: etp}
+            self.assertEqual(
+                self.loop.run_until_complete(
+                    ptr._test_steps_runner(
+                        69,
+                        fake_no_black_tests_to_run,
+                        fake_setup_py,
+                        fake_venv_path,
+                        {},
+                        True,
+                        True,
+                    )
+                ),
+                # Windows + Python 3.8 will not run pyre
+                (None, 5) if ptr.WINDOWS or ptr.GREATER_THAN_37 else (None, 6),
+            )
+
+            # Run everything but test_suite with print-cov
+            self.assertEqual(
+                self.loop.run_until_complete(
+                    ptr._test_steps_runner(
+                        69,
+                        fake_no_black_tests_to_run,
+                        fake_setup_py,
+                        fake_venv_path,
+                        {},
+                        {},
+                        True,
+                        True
+                    )
+                ),
+                # Windows + Python 3.8 will not run pyre
+                (None, 6) if ptr.WINDOWS or ptr.GREATER_THAN_37 else (None, 7),
+            )
+
             # Ensure we've "printed coverage"
             self.assertTrue(mock_print.called)
 


### PR DESCRIPTION
Summary:
- Currently, prt does not proceed if `test_suite` param is not provided. This diff removes this dependancy. 
- If `test_suite` if not provided, prt will run all other specified tests (i.e black, mypy, flake8, etc), except unit tests.

Test Plan:
- Tested the unit tests using `ci.py`. Also tested manually on nms/nano's topology service. 
- Only `test_async_main` is failing. 
```
test_analyze_coverage (ptr_tests.TestPtr) ... ok
test_analyze_coverage_errors (ptr_tests.TestPtr) ... ok
test_async_main (ptr_tests.TestPtr) ... FAIL
test_config (ptr_tests.TestPtr) ... ok
test_create_venv (ptr_tests.TestPtr) ... ok
test_find_setup_py (ptr_tests.TestPtr) ... ok
test_find_setup_py_exclude_default (ptr_tests.TestPtr) ... ok
test_gen_output (ptr_tests.TestPtr) ... ok
test_generate_black_command (ptr_tests.TestPtr) ... ok
test_generate_flake8_command (ptr_tests.TestPtr) ... ok
test_generate_install_cmd (ptr_tests.TestPtr) ... ok
test_generate_mypy_cmd (ptr_tests.TestPtr) ... ok
test_generate_pylint_command (ptr_tests.TestPtr) ... ok
test_generate_pyre_cmd (ptr_tests.TestPtr) ... ok
test_generate_test_suite_cmd (ptr_tests.TestPtr) ... ok
test_get_site_packages_path_error (ptr_tests.TestPtr) ... ok
test_get_test_modules (ptr_tests.TestPtr) ... ok
test_handle_debug (ptr_tests.TestPtr) ... ok
test_mac_osx_slash_private (ptr_tests.TestPtr) ... ok
test_main (ptr_tests.TestPtr) ... ok
test_parse_setup_cfg (ptr_tests.TestPtr) ... ok
test_print_non_configured_modules (ptr_tests.TestPtr) ... ok
test_print_test_results (ptr_tests.TestPtr) ... ok
test_process_reporter (ptr_tests.TestPtr) ... ok
test_set_build_env (ptr_tests.TestPtr) ... ok
test_set_pip_mirror (ptr_tests.TestPtr) ... ok
test_test_runner (ptr_tests.TestPtr) ... ok
test_test_steps_runner (ptr_tests.TestPtr) ... ok
test_validate_base_dir (ptr_tests.TestPtr) ... ok
test_validate_base_dir_fail (ptr_tests.TestPtr) ... ok
test_write_stats_file (ptr_tests.TestPtr) ... ok
test_write_stats_file_raise (ptr_tests.TestPtr) ... ok

======================================================================
FAIL: test_async_main (ptr_tests.TestPtr)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.2_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/unittest/mock.py", line 1195, in patched
    return func(*args, **keywargs)
  File "/Users/spurav/Desktop/repo/ptr/ptr_tests.py", line 191, in test_async_main
    self.loop.run_until_complete(ptr.async_main(*args)), 2  # pyre-ignore
AssertionError: None != 2

----------------------------------------------------------------------
Ran 32 tests in 0.377s
```

```
root@5ad67badd5bd:/usr/local/nano/topology_service# ptr --venv /tmp/ptr_venv_18 
[2019-11-11 20:22:55,820] INFO: Starting /usr/local/bin/ptr (ptr.py:1129)
[2019-11-11 20:22:55,829] INFO: Installing /usr/local/nano/topology_service/setup.py + deps (ptr.py:633)
[2019-11-11 20:22:56,800] INFO: Not running Running  tests via coverage step (ptr.py:630)
[2019-11-11 20:22:56,800] INFO: Not running Analyzing coverage report for /usr/local/nano/topology_service/setup.py step (ptr.py:630)
[2019-11-11 20:22:56,800] INFO: Running mypy for /usr/local/nano/topology_service/setup.py (ptr.py:633)
[2019-11-11 20:22:57,067] INFO: Running black for /usr/local/nano/topology_service/setup.py (ptr.py:633)
[2019-11-11 20:22:57,217] INFO: Running flake8 for /usr/local/nano/topology_service/setup.py (ptr.py:633)
[2019-11-11 20:22:57,363] INFO: Not running Running pylint for /usr/local/nano/topology_service/setup.py step (ptr.py:630)
[2019-11-11 20:22:57,363] INFO: Not running Running pyre for /usr/local/nano/topology_service/setup.py step (ptr.py:630)
[2019-11-11 20:22:57,363] INFO: /usr/local/nano/topology_service/setup.py has passed all configured tests (ptr.py:745)
-- Summary (total time 1s):

✅ PASS: 1
❌ FAIL: 0
️⌛ TIMEOUT: 0
🔒 DISABLED: 0
💩 TOTAL: 1

-- 1 / 1 (100%) `setup.py`'s have `ptr` tests running

[2019-11-11 20:22:57,364] INFO: Not removing venv @ /tmp/ptr_venv_18 due to CLI arguments (ptr.py:998)
root@5ad67badd5bd:/usr/local/nano/topology_service# 
```


