### PR TITLE
Add LICENSE to sdist + move to 2019.11.21 + update CHANGES.md

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,14 @@
 
 Each release to PyPI I'm going to give a codename as to where I am or was in the world 🌏.
 
+### 2019.11.21
+
+Codename: **Santa Clara, CA**
+
+*@thatch lives there!**
+
+- Add license file for @thatch - PR: #77 - *Thanks @thatch*
+
 ### 2019.11.15
 
 Codename: **Russian River, CA 🇺🇸**

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include CHANGES.md
+include CHANGES.md LICENSE

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ def get_long_desc() -> str:
 
 setup(
     name=ptr_params["entry_point_module"],
-    version="19.11.15",
+    version="19.11.21",
     description="Parallel asyncio Python setup.(cfg|py) Test Runner",
     long_description=get_long_desc(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Fixes #76

```
cooper-mbp1:dist cooper$ tar xvzf ptr-19.11.21.tar.gz
x ptr-19.11.21/
x ptr-19.11.21/CHANGES.md
x ptr-19.11.21/LICENSE
x ptr-19.11.21/MANIFEST.in
x ptr-19.11.21/PKG-INFO
x ptr-19.11.21/README.md
x ptr-19.11.21/ptr.egg-info/
x ptr-19.11.21/ptr.egg-info/PKG-INFO
x ptr-19.11.21/ptr.egg-info/SOURCES.txt
x ptr-19.11.21/ptr.egg-info/dependency_links.txt
x ptr-19.11.21/ptr.egg-info/entry_points.txt
x ptr-19.11.21/ptr.egg-info/top_level.txt
x ptr-19.11.21/ptr.py
x ptr-19.11.21/ptr_tests.py
x ptr-19.11.21/ptr_tests_fixtures.py
x ptr-19.11.21/setup.cfg
x ptr-19.11.21/setup.py
```