### PR TITLE
Change coverage Data File Env Var for >= 5.0

### DIFF
--- a/ptr.py
+++ b/ptr.py
@@ -702,7 +702,7 @@ async def _test_runner(
         else None
     )
     env = _set_build_env(extra_build_env_path)
-    env["COVERAGE_FILE"] = str(cov_data_path)
+    env["DATA_FILE"] = str(cov_data_path)
 
     while True:
         try:

--- a/ptr.py
+++ b/ptr.py
@@ -702,6 +702,8 @@ async def _test_runner(
         else None
     )
     env = _set_build_env(extra_build_env_path)
+    # TODO: Remove COVERAGE_FILE once coverage < 5.0 becomes less used
+    env["COVERAGE_FILE"] = str(cov_data_path)
     env["DATA_FILE"] = str(cov_data_path)
 
     while True:

--- a/ptr_tests.py
+++ b/ptr_tests.py
@@ -455,6 +455,7 @@ class TestPtr(unittest.TestCase):
             self.assertTrue("[global]" in conf_file)
             self.assertTrue("/simple" in conf_file)
 
+    @patch("ptr._using_coverage_5", async_none)
     @patch("ptr._test_steps_runner", fake_test_steps_runner)
     def test_test_runner(self) -> None:
         queue = asyncio.Queue()  # type: asyncio.Queue
@@ -537,6 +538,14 @@ class TestPtr(unittest.TestCase):
 
             # Ensure we've "printed coverage"
             self.assertEqual(mock_print.call_count, 1)
+
+    @patch("ptr._gen_check_output", return_bytes_output)
+    def test_using_coverage_5(self) -> None:
+        self.assertFalse(
+            self.loop.run_until_complete(
+                ptr._using_coverage_5(Path("venvs/test"), timeout=1)
+            )
+        )
 
     def test_validate_base_dir(self) -> None:
         path_str = gettempdir()


### PR DESCRIPTION
- In 5.0 the ENV Var has changed to DATA_FILE rather than COVERAGE_FILE
-- https://coverage.readthedocs.io/en/coverage-5.0/config.html#run
Test: Run on my MAC and see coverage data analyzed again

Fixes #84