### PR TITLE
Realphabetize command line args

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For **faster runs** when testing, it is recommended to reuse a Virtual Environme
 usage: ptr.py [-h] [-a ATONCE] [-b BASE_DIR] [-d] [-e] [-k] [-m MIRROR]
               [--print-cov] [--print-non-configured]
               [--progress-interval PROGRESS_INTERVAL] [--run-disabled]
-              [--system-site-packages] [--stats-file STATS_FILE] [--venv VENV]
+              [--stats-file STATS_FILE] [--system-site-packages] [--venv VENV]
               [--venv-timeout VENV_TIMEOUT]
 
 optional arguments:
@@ -82,12 +82,12 @@ optional arguments:
                         Seconds between status update on test running
                         [Default: Disabled]
   --run-disabled        Force any disabled tests suites to run
-  --system-site-packages
-                        Give the virtual environment access to the system
-                        site-packages dir
   --stats-file STATS_FILE
                         JSON statistics file [Default: /var/folders/tc/hbwxh76
                         j1hn6gqjd2n2sjn4j9k1glp/T/ptr_stats_12510]
+  --system-site-packages
+                        Give the virtual environment access to the system
+                        site-packages dir
   --venv VENV           Path to venv to reuse
   --venv-timeout VENV_TIMEOUT
                         Timeout in seconds for venv creation + deps install

--- a/ptr.py
+++ b/ptr.py
@@ -1119,14 +1119,14 @@ def main() -> None:
         help="Force any disabled tests suites to run",
     )
     parser.add_argument(
-        "--system-site-packages",
-        action="store_true",
-        help="Give the virtual environment access to the system site-packages dir",
-    )
-    parser.add_argument(
         "--stats-file",
         default=str(default_stats_file),
         help="JSON statistics file [Default: {}]".format(default_stats_file),
+    )
+    parser.add_argument(
+        "--system-site-packages",
+        action="store_true",
+        help="Give the virtual environment access to the system site-packages dir",
     )
     parser.add_argument("--venv", help="Path to venv to reuse")
     parser.add_argument(


### PR DESCRIPTION
I accidentally messed up the order of args in the last PR. "system-site-packages" should come after "stats-file".