### PR TITLE
Coverage hack uneeded

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ ptr.py:602:25 Undefined name [18]: Global name `stdout` is not defined, or there
 
 ### Q. How do I get specific version of black, coverage, mypy etc.?
 
-- Just simply hard set the version in the .ptrconfig in your repo
+- Just simply hard set the version in the .ptrconfig in your repo or use `requirements.txt` to pre-install before running `ptr`
 - All `pip` [PEP 440 version specifiers](https://www.python.org/dev/peps/pep-0440/) are supported
 
 ### Q. Why is the venv creation so slow?
@@ -345,6 +345,12 @@ ptr.py:602:25 Undefined name [18]: Global name `stdout` is not defined, or there
 ### Q. Why is ptr not able to run `pyre` on Windows?
 
 - `pyre` (pyre-check on PyPI) does not ship a Windows wheel with the ocaml pyre.bin
+
+
+### Q. Why do you depend on >= coverage 5.0.1
+
+- `coverage` 5.0 introduced using sqlite and we don't want to have a mix of 4.x and 5.x for ptr
+- < 5.0 could possibly still work as we now ensure to run each projects tests from setup_py.parent CWD with subprocess
 
 
 # Contact or join the ptr community 💬

--- a/ptr.py
+++ b/ptr.py
@@ -282,7 +282,7 @@ def _generate_install_cmd(
 
 def _generate_test_suite_cmd(coverage_exe: Path, config: Dict) -> Tuple[str, ...]:
     if config.get("test_suite", False):
-        return (str(coverage_exe), "run", "--parallel-mode", "-m", config["test_suite"])
+        return (str(coverage_exe), "run", "-m", config["test_suite"])
     return ()
 
 

--- a/ptr_tests.py
+++ b/ptr_tests.py
@@ -278,7 +278,7 @@ class TestPtr(unittest.TestCase):
         config = {"test_suite": "dummy_test.base"}
         self.assertEqual(
             ptr._generate_test_suite_cmd(coverage_exe, config),
-            (str(coverage_exe), "run", "-m", config["test_suite"]),
+            (str(coverage_exe), "run", "--parallel-mode", "-m", config["test_suite"]),
         )
         config = {}
         self.assertEqual(ptr._generate_test_suite_cmd(coverage_exe, config), ())
@@ -455,7 +455,6 @@ class TestPtr(unittest.TestCase):
             self.assertTrue("[global]" in conf_file)
             self.assertTrue("/simple" in conf_file)
 
-    @patch("ptr._using_coverage_5", async_none)
     @patch("ptr._test_steps_runner", fake_test_steps_runner)
     def test_test_runner(self) -> None:
         queue = asyncio.Queue()  # type: asyncio.Queue
@@ -538,14 +537,6 @@ class TestPtr(unittest.TestCase):
 
             # Ensure we've "printed coverage"
             self.assertEqual(mock_print.call_count, 1)
-
-    @patch("ptr._gen_check_output", return_bytes_output)
-    def test_using_coverage_5(self) -> None:
-        self.assertFalse(
-            self.loop.run_until_complete(
-                ptr._using_coverage_5(Path("venvs/test"), timeout=1)
-            )
-        )
 
     def test_validate_base_dir(self) -> None:
         path_str = gettempdir()

--- a/ptr_tests.py
+++ b/ptr_tests.py
@@ -278,7 +278,7 @@ class TestPtr(unittest.TestCase):
         config = {"test_suite": "dummy_test.base"}
         self.assertEqual(
             ptr._generate_test_suite_cmd(coverage_exe, config),
-            (str(coverage_exe), "run", "--parallel-mode", "-m", config["test_suite"]),
+            (str(coverage_exe), "run", "-m", config["test_suite"]),
         )
         config = {}
         self.assertEqual(ptr._generate_test_suite_cmd(coverage_exe, config), ())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 black
-coverage
+coverage>=5.0.1
 flake8
 mypy
 pip


### PR DESCRIPTION
- Revert uneeded coverage 5.0 hack as we cwd into setup_py_path.parent
- 5.0.1 also fixes/better errors the bug with an old 4.x coverage file existing