### PR TITLE
Add yaml front matter to issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,4 +1,11 @@
-Thanks for logging an issue with `ptr`. Here are some questions to help try 
+---
+name: Bug report
+about: Create a report to help us improve
+labels: bug
+
+---
+
+Thanks for logging an issue with `ptr`. Here are some questions to help try
 and pull out as much information possible to help us help you!
 
 ## How is `ptr` not doing what you expect?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,3 +1,10 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: enhancement
+
+---
+
 Summary:
 - Please give us some dot points on why you made this PR
 


### PR DESCRIPTION
https://docs.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates states that the updated template formats should include YAML front matter.

> To be included in the community profile checklist, issue templates must be located in the .github/ISSUE_TEMPLATE folder and contain valid name: and about: YAML front matter.

