### PR TITLE
Drop Python 3.6 support + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [macOS-latest, ubuntu-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.4.0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -10,12 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2.4.0
 
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
+    - name: Set up Python 3
+      uses: actions/setup-python@v2.3.1
 
     - name: Install latest pip, setuptools, twine + wheel
       run: |

--- a/ptr_tests.py
+++ b/ptr_tests.py
@@ -13,8 +13,8 @@ from os import environ
 from pathlib import Path
 from shutil import rmtree
 from subprocess import CalledProcessError
-from tempfile import TemporaryDirectory, gettempdir
-from typing import (  # noqa: F401 # pylint: disable=unused-import
+from tempfile import gettempdir, TemporaryDirectory
+from typing import (  # noqa: F401  # pylint: disable=unused-import
     Any,
     Dict,
     List,

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ def get_long_desc() -> str:
 
 setup(
     name=ptr_params["entry_point_module"],
-    version="21.11.23",
+    version="22.2.X",
     description="Parallel asyncio Python setup.(cfg|py) Test Runner",
     long_description=get_long_desc(),
     long_description_content_type="text/markdown",
@@ -64,13 +64,12 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=None,
     entry_points={"console_scripts": ["ptr = ptr:main"]},
     test_suite=ptr_params["test_suite"],


### PR DESCRIPTION
- Up python_requires >= 3.7
- Stop Actions running 3.6
- Update some actions versions

Python 3.6 was EOL 12/23/2021