### PR TITLE
Add pyproject.toml support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Run Unitests via coverage
       run: |
-        python -m pip install coverage
+        python -m pip install . coverage
         coverage run ptr_tests.py -v
 
     - name: Show coverage

--- a/.github/workflows/ci_latest.yml
+++ b/.github/workflows/ci_latest.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Run Unitests via coverage
         run: |
-          python -m pip install coverage
+          python -m pip install . coverage
           coverage run ptr_tests.py -v
 
       - name: Show coverage

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools
-          python -m pip install coverage hypothesis
+          python -m pip install . coverage hypothesis
 
       - name: Run fuzz tests
         run: |

--- a/README.md
+++ b/README.md
@@ -131,11 +131,19 @@ ptr_params = {
 }
 ```
 
+### `pyproject.toml`
+
+This is per project in your repository and if exists is preferred over `setup.py` and `setup.cfg`.
+
+Please refer to [`pyproject.toml`](http://github.com/facebookincubator/ptr/blob/master/pyproject.toml)
+for the options available + format.
+
 ### `setup.cfg`
 
 This is per project in your repository and if exists is preferred over `setup.py`.
 
-Please refer to [`setup.cfg.sample`](http://github.com/facebookincubator/ptr/blob/master/setup.cfg.sample) for the options available + format.
+Please refer to [`setup.cfg.sample`](http://github.com/facebookincubator/ptr/blob/master/setup.cfg.sample)
+for the options available + format.
 
 ### mypy Specifics
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Python Test Runner (ptr) was born to run tests in an opinionated way, within arb
 - `ptr` itself uses `ptr` to run its tests 👌🏼
 - `ptr` is supported and tested on *Linux*, *MacOS* + *Windows* Operating Systems
 
-By adding `ptr` configuration to your `setup.cfg` or `setup.py` you can have `ptr` perform the following, per test suite, in parallel:
+By adding `ptr` configuration to your either of your `pyproject.toml`, `setup.cfg` or `setup.py` you can have `ptr` perform the following,
+per test suite, in parallel:
+
 - run your test suite
 - check and enforce coverage requirements (via [coverage](https://pypi.org/project/coverage/)),
 - format code (via [black](https://pypi.org/project/black/))
@@ -36,7 +38,7 @@ ptr
 I'm glad you ask. Under the covers `ptr` performs:
 - Recursively searches for `setup.(cfg|py)` files from `BASE_DIR` (defaults to your "current working directory" (CWD))
    - [AST](https://docs.python.org/3/library/ast.html) parses out the config for each `setup.py` test requirements
-   - If a `setup.cfg` exists, load via configparser and prefer if a `[ptr]` section exists
+   - If a `pyproject.toml` or `setup.cfg` exists, load via configparser/tomli and prefer if a `[ptr]` section exists
 - Creates a [Python Virtual Environment](https://docs.python.org/3/tutorial/venv.html) (*OPTIONALLY* pointed at an internal PyPI mirror)
 - Runs `ATONCE` tests suites in parallel (i.e. per setup.(cfg|ptr))
 - All steps will be run for each suite and ONLY *FAILED* runs will have output written to stdout

--- a/ptr_tests_fixtures.py
+++ b/ptr_tests_fixtures.py
@@ -211,6 +211,21 @@ setup(
 )
 """
 
+SAMPLE_PYPROJECT = """\
+[tool.ptr]
+disabled = true
+entry_point_module = "ptr"
+test_suite = "ptr_tests"
+test_suite_timeout = 120
+required_coverage = { 'ptr.py' = 84, TOTAL = 88 }
+run_usort = true
+run_black = true
+run_mypy = true
+run_flake8 = true
+run_pylint = true
+run_pyre = true
+"""
+
 # Disabled is set as we --run-disabled the run in CI
 SAMPLE_SETUP_CFG = """\
 [ptr]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,16 @@
 [build-system]
 requires = ["setuptools>=43.0.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.ptr]
+disabled = true
+entry_point_module = "ptr"
+test_suite = "ptr_tests"
+test_suite_timeout = 120
+required_coverage = { 'ptr.py' = 84, TOTAL = 88 }
+run_usort = true
+run_black = true
+run_mypy = true
+run_flake8 = true
+run_pylint = true
+run_pyre = true

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
         "Programming Language :: Python :: 3.10",
     ],
     python_requires=">=3.7",
-    install_requires=None,
+    install_requires=["tomli>=1.1.0; python_full_version < '3.11.0a7'"],
     entry_points={"console_scripts": ["ptr = ptr:main"]},
     test_suite=ptr_params["test_suite"],
 )


### PR DESCRIPTION
- [tool.ptr] Section support in pyproject.toml
- Parses the toml into the same dict structure as `setup.cfg` + `setup.py` now
- `pyproject.toml` is more preferred than `setup.cfg` + `setup.py`

Test:
- Add unittest for parsing pyproject.toml
- See Integration test stay working as pyproject.toml would be preferred
- @patch mock to keep test_get_test_modules go through the if statements for coverage

Fixes #91

This does not change ptr to install using pyproject.toml yet ... just suport projects with ptr config in there.